### PR TITLE
ci: switch release workflow to npm Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Force npm publish even if the tag already exists (does not re-tag or re-create the GitHub Release).'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -18,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
           cache: npm
 
@@ -35,20 +42,29 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Decide whether to build & publish
+        id: gate
+        run: |
+          if [ "${{ steps.tagcheck.outputs.exists }}" = "false" ] || [ "${{ inputs.force_publish }}" = "true" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install
-        if: steps.tagcheck.outputs.exists == 'false'
+        if: steps.gate.outputs.run == 'true'
         run: npm ci
 
       - name: Lint
-        if: steps.tagcheck.outputs.exists == 'false'
+        if: steps.gate.outputs.run == 'true'
         run: npm run lint
 
       - name: Test
-        if: steps.tagcheck.outputs.exists == 'false'
+        if: steps.gate.outputs.run == 'true'
         run: npm test
 
       - name: Build
-        if: steps.tagcheck.outputs.exists == 'false'
+        if: steps.gate.outputs.run == 'true'
         run: npm run build
 
       - name: Extract release notes
@@ -83,11 +99,9 @@ jobs:
           body_path: .release-notes.md
 
       - name: Publish to npm
-        if: steps.tagcheck.outputs.exists == 'false'
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+        if: steps.gate.outputs.run == 'true'
+        run: npm publish --provenance --access public
 
       - name: Skip
-        if: steps.tagcheck.outputs.exists == 'true'
-        run: echo "Tag v${{ steps.pkg.outputs.version }} already exists, nothing to release."
+        if: steps.gate.outputs.run == 'false'
+        run: echo "Tag v${{ steps.pkg.outputs.version }} already exists and force_publish is false, nothing to do."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `init` now adds `.env` to the project root `.gitignore` so dumped secrets cannot be committed by accident.
 - GitHub Actions workflow `ci.yml` runs lint, build, and tests on every pull request.
-- GitHub Actions workflow `release.yml` auto-tags, releases, and publishes to npm whenever `main` advances and `package.json` `version` does not yet have a matching git tag.
+- GitHub Actions workflow `release.yml` auto-tags, releases, and publishes to npm whenever `main` advances and `package.json` `version` does not yet have a matching git tag. The release job uses Node 20 and npm Trusted Publishing (OIDC) with provenance; it supports a `force_publish` manual dispatch input to republish a version without re-tagging.
 
 ### Removed
 - `npm-publish.yml` workflow (replaced by `release.yml`).
+- `NPM_TOKEN` secret is no longer needed; the workflow authenticates to npm via OIDC.
 
 ## [2.2.0] -  2023-01-05
 ### Added


### PR DESCRIPTION
## Context
The v2.3.0 release failed at `npm publish` because the long-lived `NPM_TOKEN` is no longer valid. npm now recommends Trusted Publishing (OIDC) for CI/CD, which removes the need for any long-lived token.

The tag `v2.3.0` and the GitHub Release for v2.3.0 were already created in the original release run, so this PR keeps them intact and only fixes the publish path.

## Changes
- Runner bumped to Node 20 (only in `release.yml`; `ci.yml` keeps Node 16 since it doesn't publish). npm 10 is required for OIDC and `--provenance`.
- `permissions: id-token: write` added so the workflow can request the OIDC token from GitHub.
- `NODE_AUTH_TOKEN` removed; `npm publish` now uses Trusted Publishing.
- `--provenance --access public` added to the publish command.
- New `workflow_dispatch` trigger with a `force_publish` boolean input. When `force_publish=true`, install/lint/test/build/publish run even if the tag already exists; tag and GitHub Release creation steps still only run when the tag does not exist. This is the recovery path for v2.3.0 and for any similar failure in the future.

## Recovery plan
1. Merge this PR into `develop`.
2. Open `develop` → `main`, merge it. The push to `main` will run the workflow, see `v2.3.0` tag already exists, and skip everything (baseline run of the new workflow).
3. Manually trigger: `gh workflow run release.yml -f force_publish=true` (or via the Actions UI). With `force_publish=true`, the workflow will install/build and `npm publish` v2.3.0 to npm with provenance.
4. Verify `npm view undisclosed@2.3.0 version` returns `2.3.0`.

## Test plan
- [ ] CI on this PR passes (`ci.yml` still on Node 16).
- [ ] After merge to `main`, the automatic push-trigger run skips publish (tag exists, no `force_publish`).
- [ ] Manual dispatch with `force_publish=true` publishes v2.3.0 to npm successfully with provenance.