### PR TITLE
Fix npm publish for v2.3.0 (Trusted Publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Force npm publish even if the tag already exists (does not re-tag or re-create the GitHub Release).'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -18,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
           cache: npm
 
@@ -35,20 +42,29 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Decide whether to build & publish
+        id: gate
+        run: |
+          if [ "${{ steps.tagcheck.outputs.exists }}" = "false" ] || [ "${{ inputs.force_publish }}" = "true" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install
-        if: steps.tagcheck.outputs.exists == 'false'
+        if: steps.gate.outputs.run == 'true'
         run: npm ci
 
       - name: Lint
-        if: steps.tagcheck.outputs.exists == 'false'
+        if: steps.gate.outputs.run == 'true'
         run: npm run lint
 
       - name: Test
-        if: steps.tagcheck.outputs.exists == 'false'
+        if: steps.gate.outputs.run == 'true'
         run: npm test
 
       - name: Build
-        if: steps.tagcheck.outputs.exists == 'false'
+        if: steps.gate.outputs.run == 'true'
         run: npm run build
 
       - name: Extract release notes
@@ -83,11 +99,9 @@ jobs:
           body_path: .release-notes.md
 
       - name: Publish to npm
-        if: steps.tagcheck.outputs.exists == 'false'
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+        if: steps.gate.outputs.run == 'true'
+        run: npm publish --provenance --access public
 
       - name: Skip
-        if: steps.tagcheck.outputs.exists == 'true'
-        run: echo "Tag v${{ steps.pkg.outputs.version }} already exists, nothing to release."
+        if: steps.gate.outputs.run == 'false'
+        run: echo "Tag v${{ steps.pkg.outputs.version }} already exists and force_publish is false, nothing to do."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `init` now adds `.env` to the project root `.gitignore` so dumped secrets cannot be committed by accident.
 - GitHub Actions workflow `ci.yml` runs lint, build, and tests on every pull request.
-- GitHub Actions workflow `release.yml` auto-tags, releases, and publishes to npm whenever `main` advances and `package.json` `version` does not yet have a matching git tag.
+- GitHub Actions workflow `release.yml` auto-tags, releases, and publishes to npm whenever `main` advances and `package.json` `version` does not yet have a matching git tag. The release job uses Node 20 and npm Trusted Publishing (OIDC) with provenance; it supports a `force_publish` manual dispatch input to republish a version without re-tagging.
 
 ### Removed
 - `npm-publish.yml` workflow (replaced by `release.yml`).
+- `NPM_TOKEN` secret is no longer needed; the workflow authenticates to npm via OIDC.
 
 ## [2.2.0] -  2023-01-05
 ### Added


### PR DESCRIPTION
Merges PR #9 to `main`. The v2.3.0 tag and GitHub Release already exist; this merge only fixes the publish path.

After this merges:
1. The push-triggered run of `release.yml` will see `v2.3.0` already tagged and skip every step (baseline run of the new workflow).
2. Then we trigger `gh workflow run release.yml -f force_publish=true` to publish v2.3.0 to npm with OIDC + provenance.

See PR #9 for details.