### PR TITLE
release: v2.3.1 (republish v2.3.0 contents, fix release workflow)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch:
-    inputs:
-      force_publish:
-        description: 'Force npm publish even if the tag already exists (does not re-tag or re-create the GitHub Release).'
-        type: boolean
-        default: false
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write
@@ -29,47 +23,31 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: npm
 
-      - name: Read version from package.json
+      - name: Read version from tag
         id: pkg
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Check if tag already exists
-        id: tagcheck
+      - name: Verify tag matches package.json
         run: |
-          if git rev-parse "v${{ steps.pkg.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Decide whether to build & publish
-        id: gate
-        run: |
-          if [ "${{ steps.tagcheck.outputs.exists }}" = "false" ] || [ "${{ inputs.force_publish }}" = "true" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "${{ steps.pkg.outputs.version }}" ]; then
+            echo "Tag ${{ steps.pkg.outputs.version }} does not match package.json version $PKG_VERSION" >&2
+            exit 1
           fi
 
       - name: Install
-        if: steps.gate.outputs.run == 'true'
         run: npm ci
 
       - name: Lint
-        if: steps.gate.outputs.run == 'true'
         run: npm run lint
 
       - name: Test
-        if: steps.gate.outputs.run == 'true'
         run: npm test
 
       - name: Build
-        if: steps.gate.outputs.run == 'true'
         run: npm run build
 
       - name: Extract release notes
-        if: steps.tagcheck.outputs.exists == 'false'
-        id: notes
         run: |
           VERSION="${{ steps.pkg.outputs.version }}"
           awk -v ver="$VERSION" '
@@ -78,30 +56,16 @@ jobs:
             flag { print }
           ' CHANGELOG.md > .release-notes.md
           if [ ! -s .release-notes.md ]; then
-            echo "No changelog entry for v$VERSION" >&2
+            echo "No changelog entry for $VERSION" >&2
             exit 1
           fi
 
-      - name: Create tag
-        if: steps.tagcheck.outputs.exists == 'false'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "v${{ steps.pkg.outputs.version }}"
-          git push origin "v${{ steps.pkg.outputs.version }}"
-
       - name: Create GitHub Release
-        if: steps.tagcheck.outputs.exists == 'false'
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
-          tag_name: v${{ steps.pkg.outputs.version }}
-          name: v${{ steps.pkg.outputs.version }}
+          tag_name: ${{ steps.pkg.outputs.version }}
+          name: ${{ steps.pkg.outputs.version }}
           body_path: .release-notes.md
 
       - name: Publish to npm
-        if: steps.gate.outputs.run == 'true'
         run: npm publish --provenance --access public
-
-      - name: Skip
-        if: steps.gate.outputs.run == 'false'
-        run: echo "Tag v${{ steps.pkg.outputs.version }} already exists and force_publish is false, nothing to do."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] -  2026-06-15
+### Fixed
+- Republish the v2.3.0 contents to npm. The 2.3.0 release was tagged on GitHub but never reached npm because the release workflow ran via `workflow_dispatch`, which is incompatible with npm Trusted Publishing (npm validates the calling workflow, not the file with `npm publish`, and rejects with a 404).
+
+### Changed
+- Release workflow now triggers on `push: tags: '[0-9]+.[0-9]+.[0-9]+'` instead of push-to-main. The tag is the source of truth for the release; the workflow verifies it matches `package.json` `version` before doing anything.
+- Restore the historical git tag naming convention: tags are plain semver (`2.3.1`), not prefixed with `v`. This matches `1.0.0` through `2.2.0` and is what the new tag trigger expects.
+
+### Removed
+- `workflow_dispatch` trigger and `force_publish` input on the release workflow. The trigger was incompatible with npm Trusted Publishing; the new tag-driven flow makes it unnecessary.
+
 ## [2.3.0] -  2026-06-15
 ### Fixed
 - Require both public and private key files to be present before reporting the keypair as available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "undisclosed",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "undisclosed",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "rimraf": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undisclosed",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Command line tool to handle encrypted secrets",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Context
v2.3.0 was tagged on GitHub but never reached npm. The publish call failed with:

```
404 Not Found - PUT https://registry.npmjs.org/undisclosed
'undisclosed@2.3.0' is not in this registry.
```

Per the [npm Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers):

> When GitHub Actions workflows use `workflow_call` or `workflow_dispatch` for publishing, validation checks the calling workflow's name, not the workflow containing the publish command.

This explains the 404: the dispatch-triggered run could not pass npm's calling-workflow validation, even though sigstore signed the provenance (sigstore does not enforce that validation; npm does).

## Fix
- Trigger is `push: tags: '[0-9]+.[0-9]+.[0-9]+'`. The recommended pattern from the official npm docs, adapted to our historical tag convention.
- `workflow_dispatch` and `force_publish` are removed.
- New step verifies that the pushed tag matches `package.json` `version` before doing anything.
- The workflow no longer creates the tag — the tag IS the trigger. The release engineer bumps `package.json`, commits, merges to `main`, and pushes a tag. The workflow does the rest (lint, test, build, GitHub Release, `npm publish --provenance --access public`).

## Tag naming
v2.3.0 was tagged as `v2.3.0`. That broke the repo's historical convention (`1.0.0` ... `2.2.0`, no `v` prefix). This PR restores the convention and the new trigger pattern matches it.

## Release procedure once this lands

```
git checkout main
git pull
git tag 2.3.1
git push origin 2.3.1
```

That triggers the workflow. npm gets `undisclosed@2.3.1` with provenance; GitHub gets a `2.3.1` Release.

## v2.3.0 in npm
v2.3.0 stays as a GitHub Release/tag with no corresponding npm package. v2.3.1 has identical functional content. The v2.3.0 GitHub Release will be edited post-merge to point users at v2.3.1.

## Test plan
- [ ] CI on this PR passes (`ci.yml` still on Node 16).
- [ ] After merge to `main`, push tag `2.3.1`. The new workflow runs end-to-end, creates the GitHub Release, and publishes to npm with provenance.
- [ ] `npm view undisclosed@2.3.1 version` returns `2.3.1`.
- [ ] `npm view undisclosed dist-tags.latest` returns `2.3.1`.