### PR TITLE
release: v2.3.2 (fix Trusted Publishing OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org/
           cache: npm
 
       - name: Read version from tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.1] -  2026-06-15
+## [2.3.2] -  2026-06-15
 ### Fixed
 - Republish the v2.3.0 contents to npm. The 2.3.0 release was tagged on GitHub but never reached npm because the release workflow ran via `workflow_dispatch`, which is incompatible with npm Trusted Publishing (npm validates the calling workflow, not the file with `npm publish`, and rejects with a 404).
+- Stop passing `registry-url` to `actions/setup-node` in the release job. With `registry-url` set, setup-node writes an `.npmrc` that injects a placeholder `NODE_AUTH_TOKEN` into every step, which `npm publish` then prefers over the OIDC token, producing another spurious 404. With `registry-url` removed, npm 10 performs the OIDC handshake against `registry.npmjs.org` directly and Trusted Publishing works.
 
 ### Changed
 - Release workflow now triggers on `push: tags: '[0-9]+.[0-9]+.[0-9]+'` instead of push-to-main. The tag is the source of truth for the release; the workflow verifies it matches `package.json` `version` before doing anything.
-- Restore the historical git tag naming convention: tags are plain semver (`2.3.1`), not prefixed with `v`. This matches `1.0.0` through `2.2.0` and is what the new tag trigger expects.
+- Restore the historical git tag naming convention: tags are plain semver (`2.3.2`), not prefixed with `v`. This matches `1.0.0` through `2.2.0` and is what the new tag trigger expects.
 
 ### Removed
 - `workflow_dispatch` trigger and `force_publish` input on the release workflow. The trigger was incompatible with npm Trusted Publishing; the new tag-driven flow makes it unnecessary.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "undisclosed",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "undisclosed",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "rimraf": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undisclosed",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Command line tool to handle encrypted secrets",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
v2.3.1 also failed to publish — the misleading `404 'not in this registry'` had a second cause. With `registry-url: https://registry.npmjs.org/` passed to `actions/setup-node`, setup-node writes an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` and exposes a placeholder env var `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX` to every step. `npm publish` then prefers that placeholder token over the OIDC handshake, npm rejects, and we get the 404.

The fix is to drop `registry-url` from setup-node. npm 10 with `id-token: write` performs the OIDC handshake against the default registry on its own.

## What was cleaned up
- Tag `2.3.1` and the GitHub Release `2.3.1` have been deleted (no npm package existed for it, so nothing to break for users).
- The `[2.3.1]` CHANGELOG entry has been folded into a new `[2.3.2]` entry with the additional fix described above.

## Release procedure once this lands

```
git checkout main
git pull
git tag 2.3.2
git push origin 2.3.2
```

## Test plan
- [ ] CI on this PR passes.
- [ ] After merge, pushing tag `2.3.2` runs the workflow end to end.
- [ ] `npm view undisclosed@2.3.2 version` returns `2.3.2`.
- [ ] `npm view undisclosed dist-tags.latest` returns `2.3.2`.
- [ ] Provenance attestation is visible on the npm package page.