### PR TITLE
release: v2.3.3 (upgrade setup-node to v6 for OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
-          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Read version from tag
         id: pkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.2] -  2026-06-15
+## [2.3.3] -  2026-06-16
 ### Fixed
-- Republish the v2.3.0 contents to npm. The 2.3.0 release was tagged on GitHub but never reached npm because the release workflow ran via `workflow_dispatch`, which is incompatible with npm Trusted Publishing (npm validates the calling workflow, not the file with `npm publish`, and rejects with a 404).
-- Stop passing `registry-url` to `actions/setup-node` in the release job. With `registry-url` set, setup-node writes an `.npmrc` that injects a placeholder `NODE_AUTH_TOKEN` into every step, which `npm publish` then prefers over the OIDC token, producing another spurious 404. With `registry-url` removed, npm 10 performs the OIDC handshake against `registry.npmjs.org` directly and Trusted Publishing works.
+- Republish the v2.3.0 contents to npm. The 2.3.0 release was tagged on GitHub but never reached npm. Earlier attempts (2.3.1, 2.3.2) failed during `npm publish` with the same misleading 404 / ENEEDAUTH errors, traced to two distinct release-pipeline bugs:
+  1. The original workflow triggered via `workflow_dispatch`, which is incompatible with npm Trusted Publishing (npm validates the calling workflow, not the workflow file with `npm publish`).
+  2. `actions/setup-node@v4` exports a placeholder `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX` env var to every step when `registry-url` is set. The npm CLI picks up that placeholder and uses it instead of falling back to the OIDC handshake, causing authentication to fail. Without `registry-url`, the CLI does not find any registry config and produces an `ENEEDAUTH`.
+
+  Fix: upgrade to `actions/setup-node@v6`, which no longer injects the placeholder token and lets the npm CLI prioritize OIDC authentication as documented. `registry-url` is restored, and `package-manager-cache: false` is set per npm's published guidance for release builds.
 
 ### Changed
 - Release workflow now triggers on `push: tags: '[0-9]+.[0-9]+.[0-9]+'` instead of push-to-main. The tag is the source of truth for the release; the workflow verifies it matches `package.json` `version` before doing anything.
-- Restore the historical git tag naming convention: tags are plain semver (`2.3.2`), not prefixed with `v`. This matches `1.0.0` through `2.2.0` and is what the new tag trigger expects.
+- Restore the historical git tag naming convention: tags are plain semver (`2.3.3`), not prefixed with `v`. This matches `1.0.0` through `2.2.0` and is what the new tag trigger expects.
+- Bump `actions/setup-node` from v4 to v6 in the release workflow. `ci.yml` keeps v4 since it does not publish.
 
 ### Removed
 - `workflow_dispatch` trigger and `force_publish` input on the release workflow. The trigger was incompatible with npm Trusted Publishing; the new tag-driven flow makes it unnecessary.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "undisclosed",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "undisclosed",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "rimraf": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undisclosed",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Command line tool to handle encrypted secrets",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Third attempt at fixing the broken release pipeline. Previous attempts:

- **v2.3.1** failed: removed `workflow_dispatch` (correct), but `setup-node@v4 + registry-url` injects a placeholder `NODE_AUTH_TOKEN` that npm CLI picks up over OIDC. Got 404.
- **v2.3.2** failed: dropped `registry-url` to avoid the placeholder. But then npm CLI has no registry config at all and returns `ENEEDAUTH`.

## Root cause
`actions/setup-node@v4` and earlier exports `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX` as a placeholder env var when you pass `registry-url`. The npm CLI uses that placeholder for auth and never falls back to OIDC.

[`actions/setup-node@v6`](https://github.com/actions/setup-node/releases/tag/v6.0.0) (Oct 2025) changed this behavior: it no longer injects the placeholder, so the npm CLI's documented OIDC-first auth path actually runs.

This matches the official npm Trusted Publishing example, which uses `setup-node@v6` with `registry-url` set and `package-manager-cache: false`.

## Changes
- `actions/setup-node@v4` → `@v6` (only in `release.yml`; `ci.yml` keeps v4 since it does not publish).
- Restore `registry-url: https://registry.npmjs.org` (safe again with v6).
- Add `package-manager-cache: false` per npm's published guidance for release builds.

## Cleanup
- Tag `2.3.2` and the GitHub Release `2.3.2` have been deleted (no npm package existed, nothing to break).
- `[2.3.2]` CHANGELOG entry folded into a new `[2.3.3]` entry documenting both fixes.

## Release procedure once this lands

```
git checkout main && git pull
git tag 2.3.3
git push origin 2.3.3
```

## Test plan
- [ ] CI passes on this PR.
- [ ] After merge, pushing tag `2.3.3` runs the workflow end to end.
- [ ] `npm view undisclosed@2.3.3 version` returns `2.3.3`.
- [ ] `npm view undisclosed dist-tags.latest` returns `2.3.3`.
- [ ] Provenance attestation is visible on the npm package page.